### PR TITLE
Agrego caso de prueba TC002 login inválido

### DIFF
--- a/manual-tests/caso_prueba_login_invalido.md
+++ b/manual-tests/caso_prueba_login_invalido.md
@@ -1,0 +1,5 @@
+# Caso de Prueba: Inicio de Sesión con credenciales inválidas
+
+| ID Caso | Módulo | Descripción | Precondiciones | Pasos | Datos de Prueba | Resultado Esperado | Resultado Obtenido | Estado |
+|---------|--------|-------------|----------------|-------|-----------------|--------------------|--------------------|--------|
+| TC002   | Login  | Verificar que el sistema no permita iniciar sesión con credenciales inválidas | Usuario no registrado o credenciales incorrectas | 1. Abrir la aplicación <br> 2. Ingresar usuario no registrado <br> 3. Ingresar contraseña inválida <br> 4. Hacer clic en “Iniciar sesión” | Usuario: `fake@test.com` <br> Contraseña: `WrongPass123` | El sistema muestra un mensaje de error: “Usuario o contraseña inválidos” y no permite el acceso | - | Pendiente |


### PR DESCRIPTION
Caso negativo de login con usuario no registrado y contraseña inválida. Se espera mensaje de error: "Usuario o contraseña inválidos".